### PR TITLE
new attrium learner assignment searchable list

### DIFF
--- a/src/components/WikiTags/Question/TurkTalk/Atrium/AssigneeSearchableList/AssigneeSearchableList.js
+++ b/src/components/WikiTags/Question/TurkTalk/Atrium/AssigneeSearchableList/AssigneeSearchableList.js
@@ -1,0 +1,76 @@
+// @flow
+import React, { PureComponent } from "react";
+import { withStyles } from "@material-ui/core/styles";
+import classNames from "classnames";
+import {
+  List,
+  ListItem,
+  TextField,
+  Typography,
+} from "@material-ui/core";
+
+import styles, { SearchWrapper, ListItemContent, MapListWrapper } from "./styles";
+
+class AssigneeSearchableList extends PureComponent {
+  isMatchingQuery(item) {
+    const { query='' } = this.state || {};
+    // basic case-insensitive string search
+    const cleanup = (str) => str.toLowerCase().replace(/\s/g, '').trim()
+
+    // empty query, return all
+    if ( 0 == query.trim().length )
+      return true
+
+    return -1 != cleanup(item.text).indexOf(cleanup(query))
+  }
+
+  render() {
+    const { query='' } = this.state || {};
+    const { classes, list } = this.props;
+    const listClassNames = classNames(classes.list);
+    const filteredList = list.filter(this.isMatchingQuery.bind(this))
+
+    return (
+      <div>
+        <SearchWrapper>
+          <TextField
+            type="search"
+            name="query"
+            label={'Search for learners by name'}
+            className={classes.searchField}
+            value={query}
+            onChange={(e) => this.setState({ query: e.target.value })}
+            fullWidth
+          />
+        </SearchWrapper>
+
+        <MapListWrapper>
+          <List classes={{ root: listClassNames }} disablePadding>
+            {filteredList.map((listItem) => (
+              <ListItem
+                key={listItem.id}
+                classes={{ root: classes.listItem }}
+                onClick={e => void e.preventDefault() || this.props.selectItem(listItem)}
+              >
+                <ListItemContent>
+                  <span>{listItem.text}</span>
+                  <small>Assign</small>
+                </ListItemContent>
+              </ListItem>
+            ))}
+
+            {!filteredList.length && (
+              <ListItem classes={{ root: classes.emptyListItem }}>
+                <Typography component="span" align="right" variant="caption">
+                  {query.trim().length > 0 ? 'No matches found...' : 'Waiting for participants...'}
+                </Typography>
+              </ListItem>
+            )}
+          </List>
+        </MapListWrapper>
+      </div>
+    );
+  }
+}
+
+export default withStyles(styles)(AssigneeSearchableList);

--- a/src/components/WikiTags/Question/TurkTalk/Atrium/AssigneeSearchableList/styles.js
+++ b/src/components/WikiTags/Question/TurkTalk/Atrium/AssigneeSearchableList/styles.js
@@ -1,0 +1,86 @@
+import styled from "styled-components";
+
+import { GREY, DARK_GREY } from "../../../../../../shared/colors";
+
+export const SearchWrapper = styled.div`
+  position: relative;
+`;
+
+export const MapListWrapper = styled.div`
+  max-height: 50vh;
+  overflow: auto;
+`;
+
+export const ListItemContent = styled.div`
+  width: 100%;
+  padding: 10px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+
+  small {
+    display: none;
+    font-style: italic;
+    font-size: small;
+    color: ${DARK_GREY};
+    user-select: none;
+  }
+
+  &:hover > small {
+    display: block;
+  }
+
+  &:hover {
+    background-color: ${GREY};
+  }
+`;
+
+const styles = () => ({
+  list: {
+    marginBottom: 10,
+    "&::-webkit-scrollbar": {
+      width: 7,
+      backgroundColor: GREY,
+    },
+    "&::-webkit-scrollbar-thumb": {
+      backgroundColor: DARK_GREY,
+      borderRadius: 4,
+    },
+    "&::-webkit-scrollbar-button": {
+      width: 0,
+      height: 0,
+      display: "none",
+    },
+    "&::-webkit-scrollbar-corner": {
+      backgroundColor: "transparent",
+    },
+  },
+  listLimits: {
+    maxHeight: "30vh",
+    minHeight: "30vh",
+    overflowY: "auto",
+  },
+  listEmpty: {
+    marginTop: 10,
+  },
+  listItem: {
+    padding: 0,
+    margin: 2,
+  },
+  emptyListItem: {
+    padding: 0,
+    margin: 2,
+    backgroundColor: 'transparent!important',
+  },
+  searchField: {
+    marginBottom: 5,
+  },
+  '@global': {
+    'li:nth-of-type(odd)': {
+      backgroundColor: GREY,
+    },
+  },
+});
+
+export default styles;

--- a/src/components/WikiTags/Question/TurkTalk/Atrium/Atrium.js
+++ b/src/components/WikiTags/Question/TurkTalk/Atrium/Atrium.js
@@ -18,6 +18,7 @@ import localCss from "./Atrium.module.css";
 import styles from "../../../styles.module.css";
 import Participant from "../../../../../helpers/participant";
 import SlotInfo from "../../../../../helpers/SlotInfo";
+import AssigneeSearchableList from "./AssigneeSearchableList/AssigneeSearchableList";
 const playerState = require("../../../../../utils/PlayerState").PlayerState;
 var constants = require("../../../../../services/constants");
 
@@ -217,36 +218,52 @@ class Atrium extends React.Component {
     const { atriumLearners, selectedLearnerUserId } = this.state;
 
     return (
-      <Grid container>
-        <Grid item xs={3}>
-          <FormLabel>Atrium ({atriumLearners.length} waiting)</FormLabel>
-          <Select
-            value={selectedLearnerUserId}
-            onChange={this.onAtriumLearnerSelected}
-            style={{ width: "100%" }}
-          >
-            <MenuItem key="0" value="0">
-              <em>--Select--</em>
-            </MenuItem>
-            {atriumLearners.map((item) => (
-              <MenuItem key={item.userId} value={item.userId}>
-                {item.nickName}
+      <>
+        <FormLabel>Atrium ({atriumLearners.length} waiting)</FormLabel>
+        <AssigneeSearchableList
+          list={atriumLearners.map(learner => ({
+            id: learner.userId,
+            text: learner.nickName
+          }))}
+          selectItem={({ id }) =>
+          {
+            // select a learner by id from the atrium list
+            const learner = atriumLearners.find(learner => learner.userId == id)
+            log.debug('atrium learner selected', learner)
+          }}
+          />
+
+        <Grid container>
+          <Grid item xs={3}>
+            <FormLabel>Atrium ({atriumLearners.length} waiting)</FormLabel>
+            <Select
+              value={selectedLearnerUserId}
+              onChange={this.onAtriumLearnerSelected}
+              style={{ width: "100%" }}
+            >
+              <MenuItem key="0" value="0">
+                <em>--Select--</em>
               </MenuItem>
-            ))}
-          </Select>
+              {atriumLearners.map((item) => (
+                <MenuItem key={item.userId} value={item.userId}>
+                  {item.nickName}
+                </MenuItem>
+              ))}
+            </Select>
+          </Grid>
+          <Grid container item xs={1}>
+            <Button
+              variant="contained"
+              color="primary"
+              size="small"
+              className={localCss.assignButton}
+              onClick={this.onAssignClicked}
+            >
+              &nbsp;Assign&nbsp;
+            </Button>
+          </Grid>
         </Grid>
-        <Grid container item xs={1}>
-          <Button
-            variant="contained"
-            color="primary"
-            size="small"
-            className={localCss.assignButton}
-            onClick={this.onAssignClicked}
-          >
-            &nbsp;Assign&nbsp;
-          </Button>
-        </Grid>
-      </Grid>
+      </>
     );
   }
 }


### PR DESCRIPTION
This PR adds a generic searchable list field for assigning atrium learners, as discussed last week. 

See https://olabrats.atlassian.net/browse/OL-155

Import:

```js
import AssigneeSearchableList from "/path/to/AssigneeSearchableList/AssigneeSearchableList";
```

Usage:

```js
// pass an array of { id: number, text: string } elements type to the `list` prop.
// pass a callback to via the `selectItem` prop, to receive the { id: number, text: string } of the selected learner to assign
// i.e. ({ id: number, text: string }) => void

<AssigneeSearchableList
  list={atriumLearners.map(learner => ({
    id: learner.userId,
    text: learner.nickName
  }))}
  selectItem={({ id }) =>
  {
    // select a learner by id from the atrium list
    const learner = atriumLearners.find(learner => learner.userId == id)
    log.debug('atrium learner selected', learner)
  }}
  />
```