### PR TITLE
Login fixes and `AbortSignal.timeout` polyfill

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -1,10 +1,8 @@
 import { PureComponent } from "react";
-import React, { useEffect, useState } from "react";
+import React from "react";
 import {
   Routes,
   Route,
-  useParams,
-  useNavigate,
   useLocation,
 } from "react-router-dom";
 import "./App.css";
@@ -216,6 +214,18 @@ class App extends PureComponent {
       return <></>;
     }
   }
+}
+
+function NoMatch() {
+  let location = useLocation();
+
+  return (
+    <div>
+      <h4>
+        Page not found <code>{location.pathname}</code>
+      </h4>
+    </div>
+  );
 }
 
 // import { useState } from "react";

--- a/src/components/Login/Login.js
+++ b/src/components/Login/Login.js
@@ -25,14 +25,28 @@ function Alert(props) {
   return <MuiAlert elevation={6} variant="filled" {...props} />;
 }
 
+let MOUNTED = false;
+
+const useStateWrapper = (...args) =>
+{
+  const [val, setter] = useState(...args);
+  return [val, (...args) => MOUNTED && setter(...args)];
+};
+
 const Login = ({ setCredentials, message, authActions, classes }) => {
-  const [username, setUserName] = useState("");
-  const [password, setPassword] = useState("");
-  const [error, setError] = React.useState({
+  useEffect(() =>
+  {
+    MOUNTED = true;
+    return () => MOUNTED = false;
+  }, []);
+
+  const [username, setUserName] = useStateWrapper("");
+  const [password, setPassword] = useStateWrapper("");
+  const [error, setError] = useStateWrapper({
     show: message != null,
     message: message,
   });
-  const [inProgress, setInProgress] = React.useState(false);
+  const [inProgress, setInProgress] = useStateWrapper(false);
 
   const handleClose = (event, reason) => {
     if (reason === "clickaway") {

--- a/src/index.js
+++ b/src/index.js
@@ -19,5 +19,11 @@ reportWebVitals();
 
 // safari polyfill
 if ("AbortSignal" in window) {
-  AbortSignal.timeout = AbortSignal.timeout || (() => null);
+  AbortSignal.timeout =
+    AbortSignal.timeout ||
+    ((duration) => {
+      const controller = new AbortController();
+      setTimeout(() => controller.abort(), duration);
+      return controller.signal;
+    });
 }

--- a/src/index.js
+++ b/src/index.js
@@ -16,3 +16,8 @@ ReactDOM.render(
 // to log results (for example: reportWebVitals(console.log))
 // or send to an analytics endpoint. Learn more: https://bit.ly/CRA-vitals
 reportWebVitals();
+
+// safari polyfill
+if ("AbortSignal" in window) {
+  AbortSignal.timeout = AbortSignal.timeout || (() => null);
+}


### PR DESCRIPTION
This PR fixes logins on Safari (tested against Safari 15.6.1 on OSX 10.15.7).

This adds a <strike>fake</strike> polyfill which returns null as a fallback for browsers that didn't implement `AbortSignal.timeout` yet (Safari notably). <strike>sticking with a fake callback now just to fix our login. If more issues arise I can just then spend time implementing the actual abort-signal callback.</strike>